### PR TITLE
Remove newline causing script failure

### DIFF
--- a/spiral/__version__.py
+++ b/spiral/__version__.py
@@ -14,5 +14,4 @@ __author__      = 'Michael Hucka <mhucka@caltech.edu>'
 __email__       = 'casics-team@googlegroups.com'
 __license__     = 'GNU General Public License, version 3.0'
 __copyright__   = 'Copyright (C) 2015-2017 by the California Institute of Technology'
-__citation__    = 'Hucka, (2018). Spiral: splitters for identifiers in source code files.
-Journal of Open Source Software, 3(24), 653, https://doi.org/10.21105/joss.00653'
+__citation__    = 'Hucka, (2018). Spiral: splitters for identifiers in source code files. Journal of Open Source Software, 3(24), 653, https://doi.org/10.21105/joss.00653'


### PR DESCRIPTION
…Software, 3(24), 653, https://doi.org/10.21105/joss.00653'

It was causing the following error:

Traceback (most recent call last):
  File "setup.py", line 14, in <module>
    import spiral
  File "/home/--/spiral/spiral/__init__.py", line 32, in <module>
    from .__version__ import __version__, __title__, __description__, __url__
  File "/home/--/spiral/spiral/__version__.py", line 17
    __citation__    = 'Hucka, (2018). Spiral: splitters for identifiers in source code files.

Removed newline