### PR TITLE
Update where iterable is being imported from

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Please also indicate the specific version of Spiral you use, to improve other pe
 
 For basic usage, the following is probably the simplest and most direct way to install Spiral on your computer:
 ```sh
-sudo pip3 install git+https://github.com/casics/spiral.git
+sudo pip3 install git+https://github.com/cnewman/spiral.git
 ```
 
 Alternatively, you can clone this GitHub repository and then run `setup.py`:
 ```sh
-git clone https://github.com/casics/spiral.git
+git clone https://github.com/cnewman/spiral.git
 cd spiral
 sudo python3 -m pip install .
 ```

--- a/spiral/utils.py
+++ b/spiral/utils.py
@@ -6,7 +6,10 @@
 # @website https://github.com/casics/spiral
 # =============================================================================
 
-import collections
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 def msg(string, *other_args):
     '''Like the standard print(), but treats the first argument as a string

--- a/spiral/utils.py
+++ b/spiral/utils.py
@@ -25,7 +25,7 @@ def flatten(lst):
     '''Recursively flatten a list of lists.  From the answer by user Christian
     here: https://stackoverflow.com/a/2158532/743730'''
     for el in lst:
-        if isinstance(el, collections.Iterable) and not isinstance(el, (str, bytes)):
+        if isinstance(el, Iterable) and not isinstance(el, (str, bytes)):
             yield from flatten(el)
         else:
             yield el


### PR DESCRIPTION
Patch should be backwards-compatible with older versions of Python (tested on 3.8 and 3.10)